### PR TITLE
Introducing Flask specific tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest-flask
         python -m pip install --requirement requirements.txt
     - name: Lint with flake8
       run: |

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "*"
+pytest-flask = "*"
 
 [packages]
 requests = "==2.23.0"

--- a/app.py
+++ b/app.py
@@ -2,23 +2,26 @@ from flask import Flask, request, jsonify
 
 from adapter import Adapter
 
-app = Flask(__name__)
 
+def create_app(test_config=None):
+    app = Flask(__name__)
 
-@app.before_request
-def log_request_info():
-    app.logger.debug('Headers: %s', request.headers)
-    app.logger.debug('Body: %s', request.get_data())
+    @app.before_request
+    def log_request_info():
+        app.logger.debug('Headers: %s', request.headers)
+        app.logger.debug('Body: %s', request.get_data())
 
+    @app.route('/', methods=['POST'])
+    def call_adapter():
+        data = request.get_json()
+        if data == '':
+            data = {}
+        adapter = Adapter(data)
+        return jsonify(adapter.result)
 
-@app.route('/', methods=['POST'])
-def call_adapter():
-    data = request.get_json()
-    if data == '':
-        data = {}
-    adapter = Adapter(data)
-    return jsonify(adapter.result)
+    return app
 
 
 if __name__ == '__main__':
+    app = create_app()
     app.run(debug=True, host='0.0.0.0', port='8080', threaded=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    return app

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,0 +1,8 @@
+def test_call_adapter(client):
+    assert client.post('/').status_code == 500
+    assert client.get('/').status_code == 405
+
+    rv = client.post('/', json={'id': '1', 'data': {}})
+    json_data = rv.get_json()
+    assert json_data.get('statusCode') == 500
+    assert json_data.get('status') == 'errored'


### PR DESCRIPTION
Using Flask's own testing framework, we can make API mocking an
instance context, getting a closer real-life test of the endpoints.

I confess that I overengineered a bit by adding a `conftest.py` and refactoring `app.py` but it made the system more modular and flexible allowing better development.